### PR TITLE
Bug fix to `preprocess.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+experiments/results

--- a/preprocess.py
+++ b/preprocess.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
     ds_config['train_batch_size'] = 64
     ds_config['training_set_path'] = os.path.join(args.out_dir, 'train')
     ds_config['test_set_path'] = os.path.join(args.out_dir, 'test')
-    datamodule = ds_fac[ds_config['type']](ds_config)
+    datamodule = ds_fac[ds_config['type']](ds_config, n_gpus)
     datamodule.setup()
     print('computing train set statistics needed for FID')
     init_fid(os.path.join(str(ds_config['training_set_path']) + '_stats'),

--- a/preprocess.py
+++ b/preprocess.py
@@ -114,6 +114,7 @@ if __name__ == '__main__':
     ds_config['test_set_path'] = os.path.join(args.out_dir, 'test')
     datamodule = ds_fac[ds_config['type']](ds_config, n_gpus)
     datamodule.setup()
+    #TODO: stdout was redirected to devnull, should use stderr instead? fix stdout?
     print('computing train set statistics needed for FID')
     init_fid(os.path.join(str(ds_config['training_set_path']) + '_stats'),
              datamodule.train_dataloader(),


### PR DESCRIPTION
`n_gpus` was not passed to the `init` of the dataset class, caused an exception.

Also, we redirect the `stdout` stream to `/dev/null` and never redirect it back, this results in prints (after the call to `prepare_ffhq`) has no effect. I didn't fix it because I didn't dive deep to the effects of such change, instead I added a `TODO` comment to alert users who try to debug this part of the code.

Finally, added a small `.gitignore` file for good measure.